### PR TITLE
feat: authorize endpoints + implement user

### DIFF
--- a/src/CitMovie.Api/CitMovie.Api.csproj
+++ b/src/CitMovie.Api/CitMovie.Api.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>

--- a/src/CitMovie.Api/Controller/LoginController.cs
+++ b/src/CitMovie.Api/Controller/LoginController.cs
@@ -39,8 +39,6 @@ public class LoginController : ControllerBase {
         string username = credentialParts[0];
         string password = credentialParts[1];
 
-        _logger.LogInformation($"Login attempt with username: {username} and password: {password}");
-
         try {
             string token = await _loginService.LoginAsync(username, password);
             return Ok(token);

--- a/src/CitMovie.Api/Controller/UserController.cs
+++ b/src/CitMovie.Api/Controller/UserController.cs
@@ -1,0 +1,63 @@
+namespace CitMovie.Api;
+
+[ApiController]
+[Route("api/user")]
+public class UserController : ControllerBase {
+    private readonly ILogger<UserController> _logger;
+    private readonly IUserManager _userManager;
+
+    public UserController(ILogger<UserController> logger, IUserManager userManager)
+    {
+        _logger = logger;
+        _userManager = userManager;
+    }
+
+    [Authorize(Policy = "user_scope")]
+    [HttpGet("{userId}")]
+    public async Task<ActionResult> GetUser(int userId) {
+        try {
+            UserResponse user = await _userManager.GetUserAsync(userId);
+            return Ok(user);
+        } catch (Exception ex) {
+            _logger.LogInformation(ex, "Get user failed");
+            return NotFound("User not found");
+        }
+    }
+
+    [HttpPost]
+    public async Task<ActionResult> CreateUser([FromBody] UserCreateRequest user) {
+        try {
+            UserResponse newUser = await _userManager.CreateUserAsync(user);
+            return CreatedAtAction(nameof(GetUser), new { id = newUser.Id }, newUser);
+        } catch (Exception ex) {
+            _logger.LogInformation(ex, "Create user failed");
+            return BadRequest("Create user failed");
+        }
+    }
+
+    [Authorize(Policy = "user_scope")]
+    [HttpPatch("{userId}")]
+    public async Task<ActionResult> UpdateUser(int userId, [FromBody] UserUpdateRequest user) {
+        try {
+            UserResponse updatedUser = await _userManager.UpdateUserAsync(userId, user);
+            return Ok(updatedUser);
+        } catch (Exception ex) {
+            _logger.LogInformation(ex, "Update user failed");
+            return BadRequest("Update user failed");
+        }
+    }
+
+    [Authorize(Policy = "user_scope")]
+    [HttpDelete("{userId}")]
+    public async Task<ActionResult> DeleteUser(int userId) {
+        try {
+            bool deleted = await _userManager.DeleteUserAsync(userId);
+            return deleted 
+                ? NoContent() 
+                : NotFound("User not found");
+        } catch (Exception ex) {
+            _logger.LogInformation(ex, "Delete user failed");
+            return BadRequest("Delete user failed");
+        }
+    }
+}

--- a/src/CitMovie.Api/GlobalUsings.cs
+++ b/src/CitMovie.Api/GlobalUsings.cs
@@ -1,2 +1,4 @@
+global using Microsoft.AspNetCore.Authorization;
 global using Microsoft.AspNetCore.Mvc;
 global using CitMovie.Business;
+global using CitMovie.Models.DataTransferObjects;

--- a/src/CitMovie.Api/Program.cs
+++ b/src/CitMovie.Api/Program.cs
@@ -1,7 +1,10 @@
-using CitMovie.Business;
+using System.Security.Claims;
+using System.Text;
 using CitMovie.Data;
 using CitMovie.Data.FollowRepository;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -27,6 +30,47 @@ builder.Services.AddHttpsRedirection(options =>
     options.HttpsPort = 5001;
 });
 
+
+
+builder.Services
+    .AddAuthentication(options => {
+        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+        options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+    })
+    .AddJwtBearer(options => {
+        JwtOptions jwtSettings = builder.Configuration.GetSection("JwtOptions").Get<JwtOptions>()
+            ?? new JwtOptions() {
+                Issuer = builder.Configuration.GetValue<string>("JWT_ISSUER") ?? throw new Exception("JWT Issuer not found"),
+                Audience = builder.Configuration.GetValue<string>("JWT_AUDIENCE") ?? throw new Exception("JWT Audience not found"),
+                SigningKey = builder.Configuration.GetValue<string>("JWT_SIGNING_KEY") ?? throw new Exception("JWT Signing Key not found")
+            };
+        jwtSettings.Issuer = builder.Configuration.GetValue<string>("JWT_ISSUER") ?? jwtSettings.Issuer;
+        jwtSettings.Audience = builder.Configuration.GetValue<string>("JWT_AUDIENCE") ?? jwtSettings.Audience;
+        jwtSettings.SigningKey = builder.Configuration.GetValue<string>("JWT_SIGNING_KEY") ?? jwtSettings.SigningKey;
+
+        options.TokenValidationParameters = new()
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = jwtSettings.Issuer,
+            ValidAudience = jwtSettings.Audience,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.SigningKey))
+        };
+    });
+
+builder.Services.AddAuthorization(options => {
+    options.AddPolicy("user_scope", policy => {
+        policy.RequireClaim("user_id");
+        policy.RequireAssertion(context => {
+            string? userId = (context.Resource as HttpContext)?.Request.RouteValues["userId"]?.ToString();
+            return userId != null && context.User.FindFirstValue("user_id") == userId;
+        });
+    });
+});
+
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
@@ -37,12 +81,15 @@ if (app.Environment.IsDevelopment())
     app.UseHsts();
 }
 
+app.MapControllers();
+
 app.UseHttpsRedirection();
 app.UseRouting();
 
 app.MapControllers();
 
-app.MapControllers();
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapGet("/test-connection", async (FrameworkContext context) =>
 {

--- a/src/CitMovie.Api/Program.cs
+++ b/src/CitMovie.Api/Program.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Security.Claims;
 using System.Text;
 using CitMovie.Data;
@@ -5,11 +6,41 @@ using CitMovie.Data.FollowRepository;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(options => {
+    options.AddSecurityDefinition("basic", new OpenApiSecurityScheme() {
+        Type = SecuritySchemeType.Http,
+        In = ParameterLocation.Header,
+        Scheme = "Basic",
+        Name = "Basic login"
+    });
+    options.AddSecurityDefinition("bearer", new OpenApiSecurityScheme() {
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT",
+        Description = "JWT Authorization header using the Bearer scheme."
+    });
+
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement() {
+        {
+            new OpenApiSecurityScheme() { 
+                Reference = new() { Type = ReferenceType.SecurityScheme, Id = "basic" } 
+            },
+            []
+        },
+        {
+            new OpenApiSecurityScheme {
+                Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "bearer" }
+            },
+            []
+        }
+    });
+});
+
 builder.Services.AddDbContext<FrameworkContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("PostgresConnection")));
 builder.Services.AddDbContext<DataContext>(options =>

--- a/src/CitMovie.Business/CitMovieServiceCollectionExtensions.cs
+++ b/src/CitMovie.Business/CitMovieServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ public static class CitMovieServiceCollectionExtensions
 
         services.AddScoped<IUserRepository, UserRepository>();
 
+        services.AddScoped<IUserManager, UserManager>();
         services.AddScoped<ILoginManager, LoginManager>();
         services.AddOptions<JwtOptions>()
             .Configure<IConfiguration>((options, configuration) => {

--- a/src/CitMovie.Business/GlobalUsings.cs
+++ b/src/CitMovie.Business/GlobalUsings.cs
@@ -1,3 +1,4 @@
 global using Microsoft.Extensions.Options;
 global using CitMovie.Data;
+global using CitMovie.Models.DataTransferObjects;
 global using CitMovie.Models.DomainObjects;

--- a/src/CitMovie.Business/Managers/IUserManager.cs
+++ b/src/CitMovie.Business/Managers/IUserManager.cs
@@ -1,0 +1,10 @@
+namespace CitMovie.Business;
+
+public interface IUserManager
+{
+    Task<UserResponse> GetUserAsync(string username);
+    Task<UserResponse> GetUserAsync(int id);
+    Task<UserResponse> CreateUserAsync(UserCreateRequest user);
+    Task<UserResponse> UpdateUserAsync(int id, UserUpdateRequest user);
+    Task<bool> DeleteUserAsync(int id);
+}

--- a/src/CitMovie.Business/Managers/UserManager.cs
+++ b/src/CitMovie.Business/Managers/UserManager.cs
@@ -1,0 +1,54 @@
+namespace CitMovie.Business;
+
+public class UserManager : IUserManager
+{
+    private readonly IUserRepository _userRepository;
+
+    public UserManager(IUserRepository userRepository)
+    {
+        _userRepository = userRepository;
+    }
+
+    public async Task<UserResponse> CreateUserAsync(UserCreateRequest userRequest)
+    {
+        User newUser = new User
+        {
+            Username = userRequest.Username,
+            Email = userRequest.Email,
+            Password = userRequest.Password
+        };
+        User result = await _userRepository.CreateUserAsync(newUser);
+
+        return new UserResponse(result.Id, result.Username, result.Email);
+    }
+
+    public async Task<bool> DeleteUserAsync(int id)
+        => await _userRepository.DeleteUserAsync(id);
+
+    public async Task<UserResponse> GetUserAsync(string username) {
+        User result = await _userRepository.GetUserAsync(username);
+        return new UserResponse(result.Id, result.Username, result.Email);
+    }
+
+    public async Task<UserResponse> GetUserAsync(int id)
+    {
+        User result = await _userRepository.GetUserAsync(id);
+        return new UserResponse(result.Id, result.Username, result.Email);
+    }
+
+    public async Task<UserResponse> UpdateUserAsync(int id, UserUpdateRequest userRequest)
+    {
+        User existingUser = await _userRepository.GetUserAsync(id);
+
+        User updatedUser = new User
+        {
+            Id = id,
+            Username = userRequest.Username ?? existingUser.Username,
+            Email = userRequest.Email ?? existingUser.Email,
+            Password = userRequest.Password ?? existingUser.Password
+        };
+
+        User result = await _userRepository.UpdateUserAsync(updatedUser);
+        return new UserResponse(result.Id, result.Username, result.Email);
+    }
+}

--- a/src/CitMovie.Data/GlobalUsings.cs
+++ b/src/CitMovie.Data/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using CitMovie.Models.DomainObjects;

--- a/src/CitMovie.Data/Repositories/UserRepository.cs
+++ b/src/CitMovie.Data/Repositories/UserRepository.cs
@@ -1,4 +1,3 @@
-using CitMovie.Models.DomainObjects;
 using Microsoft.EntityFrameworkCore;
 
 namespace CitMovie.Data;
@@ -12,14 +11,23 @@ public class UserRepository : IUserRepository
         _context = context;
     }
 
-    public Task<User> CreateUserAsync(User user)
+    public async Task<User> CreateUserAsync(User user)
     {
-        throw new NotImplementedException();
+        _context.Users.Add(user);
+        await _context.SaveChangesAsync();
+        return user;
     }
 
-    public Task<bool> DeleteUserAsync(int id)
-    {
-        throw new NotImplementedException();
+    public async Task<bool> DeleteUserAsync(int id)
+    {   
+        try {
+            User userToDelete = _context.Users.First(x => x.Id == id);
+            _context.Users.Remove(userToDelete);
+            await _context.SaveChangesAsync();
+            return true;
+        } catch {
+            return false;
+        }
     }
 
     public Task<User> GetUserAsync(string username)
@@ -28,8 +36,12 @@ public class UserRepository : IUserRepository
     public Task<User> GetUserAsync(int id)
         => _context.Users.FirstAsync(x => x.Id == id);
 
-    public Task<User> UpdateUserAsync(User user)
+    public async Task<User> UpdateUserAsync(User user)
     {
-        throw new NotImplementedException();
+        User existingUser = await _context.Users.FirstAsync(x => x.Id == user.Id);
+        _context.Entry(existingUser).CurrentValues.SetValues(user);
+        
+        await _context.SaveChangesAsync();
+        return existingUser;
     }
 }

--- a/src/CitMovie.Models/DataTransferObjects/User.cs
+++ b/src/CitMovie.Models/DataTransferObjects/User.cs
@@ -1,0 +1,5 @@
+namespace CitMovie.Models.DataTransferObjects;
+
+public record UserResponse(int Id, string Username, string Email);
+public record UserCreateRequest(string Username, string Email, string Password);
+public record UserUpdateRequest(string? Username, string? Email, string? Password);


### PR DESCRIPTION
This PR implements Authentication and Authorization for the API. Authorization is used on the implementation of the `UserController` to restrict users from changing other uses information. This is done through a custom policy `user_scope` that ensures that the `user_id` in the JWT token matches the user id in the resource path.
