### PR TITLE
feat: implement genres

### DIFF
--- a/src/CitMovie.Api/Controller/GenreController.cs
+++ b/src/CitMovie.Api/Controller/GenreController.cs
@@ -1,0 +1,73 @@
+using CitMovie.Business.Managers;
+using CitMovie.Models.DTOs;
+
+namespace CitMovie.Api.Controller
+{
+    [ApiController]
+    [Route("api/genres")]
+    public class GenreController : ControllerBase
+    {
+        private readonly GenreManager _genreService;
+        private readonly LinkGenerator _linkGenerator;
+
+        public GenreController(GenreManager genreService, LinkGenerator linkGenerator)
+        {
+            _genreService = genreService;
+            _linkGenerator = linkGenerator;
+        }
+
+        [HttpGet(Name = nameof(GetAllGenres))]
+        public async Task<ActionResult<IEnumerable<GenreDto>>> GetAllGenres(int page = 0, int pageSize = 10)
+        {
+            var totalItems = await _genreService.GetTotalGenresCountAsync();
+            var genres = await _genreService.GetAllGenresAsync(page, pageSize);
+
+            var result = CreatePaging(
+                nameof(GetAllGenres),
+                page,
+                pageSize,
+                totalItems,
+                genres
+            );
+
+            return Ok(result);
+        }
+
+        // HATEOAS and Pagination
+        private string? GetLink(string linkName, int page, int pageSize)
+        {
+            var uri = _linkGenerator.GetUriByName(
+                        HttpContext,
+                        linkName,
+                        new { page, pageSize }
+                        );
+            return uri;
+        }
+
+        private object CreatePaging<T>(string linkName, int page, int pageSize, int total, IEnumerable<T?> items)
+        {
+            var numberOfPages = (int)Math.Ceiling(total / (double)pageSize);
+
+            var curPage = GetLink(linkName, page, pageSize);
+
+            var nextPage = page < numberOfPages - 1
+                ? GetLink(linkName, page + 1, pageSize)
+                : null;
+
+            var prevPage = page > 0
+                ? GetLink(linkName, page - 1, pageSize)
+                : null;
+
+            var result = new
+            {
+                CurPage = curPage,
+                NextPage = nextPage,
+                PrevPage = prevPage,
+                NumberOfItems = total,
+                NumberPages = numberOfPages,
+                Items = items
+            };
+            return result;
+        }
+    }
+}

--- a/src/CitMovie.Business/CitMovieServiceCollectionExtensions.cs
+++ b/src/CitMovie.Business/CitMovieServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using CitMovie.Business.Managers;
+using CitMovie.Data.Repositories;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -23,6 +25,9 @@ public static class CitMovieServiceCollectionExtensions
         services.AddScoped<ILanguageRepository, LanguageRepository>();
         services.AddScoped<LanguageManager>();
 
+
+        services.AddScoped<IGenreRepository, GenreRepository>();
+        services.AddScoped<GenreManager>();
         
         services.AddOptions<JwtOptions>()
             .Configure<IConfiguration>((options, configuration) => {

--- a/src/CitMovie.Business/Managers/GenreManager.cs
+++ b/src/CitMovie.Business/Managers/GenreManager.cs
@@ -1,0 +1,25 @@
+using System;
+using CitMovie.Data.Repositories;
+using CitMovie.Models.DTOs;
+
+namespace CitMovie.Business.Managers;
+
+public class GenreManager
+{
+    private readonly IGenreRepository _genreRepository;
+
+    public GenreManager(IGenreRepository genreRepository)
+    {
+        _genreRepository = genreRepository;
+    }
+
+    public async Task<IEnumerable<GenreDto>> GetAllGenresAsync(int page, int pageSize)
+    {
+        return await _genreRepository.GetAllGenresAsync(page, pageSize);
+    }
+
+    public async Task<int> GetTotalGenresCountAsync()
+    {
+        return await _genreRepository.GetTotalGenresCountAsync();
+    }
+}

--- a/src/CitMovie.Data/Repositories/GenreRepository.cs
+++ b/src/CitMovie.Data/Repositories/GenreRepository.cs
@@ -1,0 +1,32 @@
+using CitMovie.Models.DTOs;
+using Microsoft.EntityFrameworkCore;
+
+namespace CitMovie.Data.Repositories;
+
+public class GenreRepository : IGenreRepository
+{
+    private readonly DataContext _context;
+
+    public GenreRepository(DataContext context)
+    {
+        _context = context;
+    }
+    public async Task<IList<GenreDto>> GetAllGenresAsync(int page, int pageSize)
+    {
+        return await _context.Genres
+            .Skip(page * pageSize)
+            .Take(pageSize)
+            .Select(g => new GenreDto
+            {
+                GenreId = g.GenreId,
+                Name = g.Name
+            })
+            .ToListAsync();
+    }
+
+    public async Task<int> GetTotalGenresCountAsync()
+    {
+        return await _context.Genres.CountAsync();
+    }
+
+}

--- a/src/CitMovie.Data/Repositories/IGenreRepository.cs
+++ b/src/CitMovie.Data/Repositories/IGenreRepository.cs
@@ -1,0 +1,9 @@
+using CitMovie.Models.DTOs;
+
+namespace CitMovie.Data.Repositories;
+
+public interface IGenreRepository
+{
+    Task<IList<GenreDto>> GetAllGenresAsync(int page, int pageSize);
+    Task<int> GetTotalGenresCountAsync();
+}

--- a/src/CitMovie.Models/DTOs/GenreDto.cs
+++ b/src/CitMovie.Models/DTOs/GenreDto.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace CitMovie.Models.DTOs;
+
+public class GenreDto
+{
+    public int GenreId { get; set; }
+    public string Name { get; set; }
+}


### PR DESCRIPTION
#21  A new feature for managing genres includess adding a new `GenreController` for handling API requests, creating a `GenreManager` for business logic, and implementing a `GenreRepository` for data access. Additionally, a `GenreDto` is introduced for data transfer between layers.

### API and Controller Enhancements:
* [`src/CitMovie.Api/Controller/GenreController.cs`](diffhunk://#diff-75490e40540e07157279b032ca257d209f336fc2741dda2571a87f2a6c9f6b34R1-R73): Added a new `GenreController` to handle genre-related API requests, including pagination and HATEOAS links.

### Business Logic Layer:
* [`src/CitMovie.Business/Managers/GenreManager.cs`](diffhunk://#diff-4a509af7400f8cb7b7c3e472d16a144bc545affacde70753eb54dcc21228258dR1-R25): Introduced `GenreManager` to encapsulate business logic for genres, including methods to fetch all genres and get the total count.

### Data Access Layer:
* [`src/CitMovie.Data/Repositories/GenreRepository.cs`](diffhunk://#diff-27a0cbcd91674b1d5a66066a64c6d1b661fc62ae4db2cad5bbbaabcfe0ec41caR1-R32): Implemented `GenreRepository` to interact with the database and fetch genre data.
* [`src/CitMovie.Data/Repositories/IGenreRepository.cs`](diffhunk://#diff-c412dcd93a807afd19e63400162f4eabe809373f0e3cddf10fbb5dc5320b33d2R1-R9): Defined `IGenreRepository` interface for genre data operations.

### Data Transfer Objects:
* [`src/CitMovie.Models/DTOs/GenreDto.cs`](diffhunk://#diff-a8fabfa7a1fb53bb365c99e2ec8abe1000c3476a357c79d148c8e4889dd460c5R1-R9): Created `GenreDto` for transferring genre data between the API, business logic, and data access layers.