### PR TITLE
feat: hashed password

### DIFF
--- a/src/CitMovie.Business.Tests/JwtTokenGeneratorUnitTest.cs
+++ b/src/CitMovie.Business.Tests/JwtTokenGeneratorUnitTest.cs
@@ -16,7 +16,8 @@ public class JwtTokenGeneratorUnitTest
         User user = new() {
             Username = A.Dummy<string>(),
             Email = A.Dummy<string>(),
-            Password = A.Dummy<string>()
+            HashedPassword = A.Dummy<string>(),
+            Salt = A.Dummy<string>()
         };
 
         JwtTokenGenerator generator = new(jwtSettings);
@@ -36,7 +37,8 @@ public class JwtTokenGeneratorUnitTest
         User user = new() {
             Username = A.Dummy<string>(),
             Email = A.Dummy<string>(),
-            Password = A.Dummy<string>()
+            HashedPassword = A.Dummy<string>(),
+            Salt = A.Dummy<string>()
         };
 
         JwtTokenGenerator generator = new(jwtSettings);
@@ -55,7 +57,8 @@ public class JwtTokenGeneratorUnitTest
         User user = new() {
             Username = A.Dummy<string>(),
             Email = A.Dummy<string>(),
-            Password = A.Dummy<string>()
+            HashedPassword = A.Dummy<string>(),
+            Salt = A.Dummy<string>()
         };
 
         JwtTokenGenerator generator = new(jwtSettings);
@@ -76,7 +79,8 @@ public class JwtTokenGeneratorUnitTest
         User user = new() {
             Username = A.Dummy<string>(),
             Email = A.Dummy<string>(),
-            Password = A.Dummy<string>()
+            HashedPassword = A.Dummy<string>(),
+            Salt = A.Dummy<string>()
         };
 
         JwtTokenGenerator generator = new(jwtSettings);
@@ -96,7 +100,8 @@ public class JwtTokenGeneratorUnitTest
         User user = new() {
             Username = A.Dummy<string>(),
             Email = A.Dummy<string>(),
-            Password = A.Dummy<string>()
+            HashedPassword = A.Dummy<string>(),
+            Salt = A.Dummy<string>()
         };
 
         JwtTokenGenerator generator = new(jwtSettings);

--- a/src/CitMovie.Business.Tests/LoginManagerUnitTest.cs
+++ b/src/CitMovie.Business.Tests/LoginManagerUnitTest.cs
@@ -12,14 +12,40 @@ public class LoginManagerUnitTest
     {
         // Arrange
         IUserRepository repository = A.Fake<IUserRepository>();
-        A.CallTo(() => repository.GetUserAsync("username")).Returns(new User { Username = "username", Password = "password", Email = "email" });
+        A.CallTo(() => repository.GetUserAsync("username")).Returns(new User { Username = "username", HashedPassword = "password", Email = "email", Salt = "salt" });
 
-        LoginManager userRepository = new LoginManager(repository, A.Fake<IJwtTokenGenerator>());
+        IPasswordHelper passwordHelper = A.Fake<IPasswordHelper>();
+        A.CallTo(() => passwordHelper.VerifyPassword(A.Dummy<string>(), A.Dummy<string>(), A.Dummy<string>())).Returns(false);
+
+        LoginManager userRepository = new LoginManager(repository, A.Fake<IJwtTokenGenerator>(), passwordHelper);
+        
 
         // Act
         Func<Task> testCode = () => userRepository.LoginAsync("username", "invalidPassword");
 
         // Act & Assert
         await Assert.ThrowsAsync<UnauthorizedAccessException>(testCode);
+    }
+
+    [Fact]
+    public async Task LoginAsync_PasswordMatch_JwtTokenIsReturned()
+    {
+        // Arrange
+        IUserRepository repository = A.Fake<IUserRepository>();
+        A.CallTo(() => repository.GetUserAsync(A<string>.Ignored)).Returns(new User { Username = "username", HashedPassword = "password", Email = "email", Salt = "salt" });
+
+        IPasswordHelper passwordHelper = A.Fake<IPasswordHelper>();
+        A.CallTo(() => passwordHelper.VerifyPassword(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored)).Returns(true);
+
+        IJwtTokenGenerator jwtTokenGenerator = A.Fake<IJwtTokenGenerator>();
+        A.CallTo(() => jwtTokenGenerator.GenerateEncodedToken(A<User>.Ignored, A<IEnumerable<string>>.Ignored)).Returns("token");
+
+        LoginManager userRepository = new LoginManager(repository, jwtTokenGenerator, passwordHelper);
+
+        // Act
+        string token = await userRepository.LoginAsync("username", "password");
+
+        // Assert
+        Assert.Equal("token", token);
     }
 }

--- a/src/CitMovie.Business.Tests/PersonManagerUnitTest.cs
+++ b/src/CitMovie.Business.Tests/PersonManagerUnitTest.cs
@@ -83,14 +83,14 @@ public class PersonManagerTest
         // Arrange
         var media = new List<Media>();
         A.CallTo(() => _personRepository.GetMediaByPersonIdAsync(1, 1, 10)).Returns(media);
-        A.CallTo(() => _mapper.Map<IEnumerable<MediaResult>>(media)).Returns(new List<MediaResult>());
+        A.CallTo(() => _mapper.Map<IEnumerable<MediaBasicResult>>(media)).Returns(new List<MediaBasicResult>());
 
         // Act
         var result = await _personManager.GetMediaByPersonIdAsync(1, 1, 10);
 
         // Assert
         A.CallTo(() => _personRepository.GetMediaByPersonIdAsync(1, 1, 10)).MustHaveHappenedOnceExactly();
-        A.CallTo(() => _mapper.Map<IEnumerable<MediaResult>>(media)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _mapper.Map<IEnumerable<MediaBasicResult>>(media)).MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -119,6 +119,5 @@ public class PersonManagerTest
 
         // Assert
         A.CallTo(() => _personRepository.GetFrequentCoActorsAsync(1, 1, 10)).MustHaveHappenedOnceExactly();
-        A.CallTo(() => _mapper.Map<IEnumerable<CoActorResult>>(coActors)).MustHaveHappenedOnceExactly();
     }
 }

--- a/src/CitMovie.Business/CitMovieServiceCollectionExtensions.cs
+++ b/src/CitMovie.Business/CitMovieServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ public static class CitMovieServiceCollectionExtensions
         services.AddAutoMapper(typeof(AutoMapperProfile));
 
         services.AddScoped<IJwtTokenGenerator, JwtTokenGenerator>();
+        services.AddScoped<IPasswordHelper, PasswordHelper>();
 
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<IMediaRepository, MediaRepository>();

--- a/src/CitMovie.Business/IPasswordHelper.cs
+++ b/src/CitMovie.Business/IPasswordHelper.cs
@@ -1,0 +1,7 @@
+namespace CitMovie.Business;
+
+public interface IPasswordHelper {
+    string GenerateSalt();
+    string HashPassword(string password, string salt);
+    bool VerifyPassword(string password, string salt, string hashedPassword);
+} 

--- a/src/CitMovie.Business/Managers/LoginManager.cs
+++ b/src/CitMovie.Business/Managers/LoginManager.cs
@@ -4,17 +4,19 @@ public class LoginManager : ILoginManager
 {
     private readonly IUserRepository _repository;
     private readonly IJwtTokenGenerator _jwtTokenGenerator;
+    private readonly IPasswordHelper _passwordHelper;
 
-    public LoginManager(IUserRepository repository, IJwtTokenGenerator jwtTokenGenerator)
+    public LoginManager(IUserRepository repository, IJwtTokenGenerator jwtTokenGenerator, IPasswordHelper passwordHelper)
     {
         _jwtTokenGenerator = jwtTokenGenerator;
+        _passwordHelper = passwordHelper;
         _repository = repository;
     }
 
     public async Task<string> LoginAsync(string username, string password)
     {
         User user = await _repository.GetUserAsync(username);
-        if (user.Password != password)
+        if (!_passwordHelper.VerifyPassword(password, user.Salt, user.HashedPassword))
             throw new UnauthorizedAccessException();
 
         return _jwtTokenGenerator.GenerateEncodedToken(user, new List<string> {"default"}); 

--- a/src/CitMovie.Business/Managers/UserManager.cs
+++ b/src/CitMovie.Business/Managers/UserManager.cs
@@ -4,16 +4,21 @@ public class UserManager : IUserManager
 {
     private readonly IUserRepository _userRepository;
     private readonly IMapper _mapper;
+    private readonly IPasswordHelper _passwordHelper;
 
-    public UserManager(IUserRepository userRepository, IMapper mapper)
+    public UserManager(IUserRepository userRepository, IMapper mapper, IPasswordHelper passwordHelper)
     {
         _userRepository = userRepository;
         _mapper = mapper;
+        _passwordHelper = passwordHelper;
     }
 
     public async Task<UserResult> CreateUserAsync(UserCreateRequest userRequest)
     {
         User newUser = _mapper.Map<User>(userRequest);
+        newUser.Salt = _passwordHelper.GenerateSalt();
+        newUser.HashedPassword = _passwordHelper.HashPassword(userRequest.Password, newUser.Salt);
+
         User result = await _userRepository.CreateUserAsync(newUser);
 
         return _mapper.Map<UserResult>(result);
@@ -37,15 +42,15 @@ public class UserManager : IUserManager
     {
         User existingUser = await _userRepository.GetUserAsync(id);
 
-        User updatedUser = new User
+        existingUser.Username = userRequest.Username ?? existingUser.Username;
+        existingUser.Email = userRequest.Email ?? existingUser.Email;
+        if (userRequest.Password != null)
         {
-            Id = id,
-            Username = userRequest.Username ?? existingUser.Username,
-            Email = userRequest.Email ?? existingUser.Email,
-            Password = userRequest.Password ?? existingUser.Password
-        };
+            existingUser.Salt = _passwordHelper.GenerateSalt();
+            existingUser.HashedPassword = _passwordHelper.HashPassword(userRequest.Password, existingUser.Salt);
+        }
 
-        User result = await _userRepository.UpdateUserAsync(updatedUser);
+        User result = await _userRepository.UpdateUserAsync(existingUser);
         return _mapper.Map<UserResult>(result);
     }
 }

--- a/src/CitMovie.Business/PasswordHelper.cs
+++ b/src/CitMovie.Business/PasswordHelper.cs
@@ -1,0 +1,32 @@
+using System.Security.Cryptography;
+
+namespace CitMovie.Business;
+
+public class PasswordHelper : IPasswordHelper
+{
+    const int salt_bitsize = 128;
+    const int hash_bitsize = 256;
+    const int iterations = 500000;
+
+    public string GenerateSalt()
+    {
+        using RandomNumberGenerator rng = RandomNumberGenerator.Create();
+        byte[] salt = new byte[salt_bitsize / 8];
+        rng.GetBytes(salt);
+        return Convert.ToBase64String(salt);
+    }
+
+    public string HashPassword(string password, string salt)
+    {
+        byte[] saltBytes = Convert.FromBase64String(salt);
+        using Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, iterations, HashAlgorithmName.SHA256);
+        byte[] hash = pbkdf2.GetBytes(hash_bitsize / 8);
+        return Convert.ToBase64String(hash);
+    }
+
+    public bool VerifyPassword(string password, string salt, string hashedPassword)
+    {
+        string computedHash = HashPassword(password, salt);
+        return computedHash == hashedPassword;
+    }
+}

--- a/src/CitMovie.Models/DataTransferObjects/UserDto.cs
+++ b/src/CitMovie.Models/DataTransferObjects/UserDto.cs
@@ -10,7 +10,13 @@ public class UserResult : BaseResult
 public record UserCreateRequest {
     public required string Username { get; set; }
     public required string Email { get; set; }
+    [MinLength(15), MaxLength(64)]
     public required string Password { get; set; }
 }
 
-public record UserUpdateRequest(string? Username, string? Email, string? Password);
+public record UserUpdateRequest {
+    public string? Username { get; set; }
+    public string? Email { get; set; }
+    [MinLength(15), MaxLength(64)]
+    public string? Password { get; set; }
+};

--- a/src/CitMovie.Models/DomainObjects/User.cs
+++ b/src/CitMovie.Models/DomainObjects/User.cs
@@ -8,13 +8,15 @@ public class User
     [Column("user_id")]
     public int Id { get; set; }
 
-    [MaxLength(50), Column("username")]
+    [Column("username")]
     public required string Username { get; set; }
 
-    [MaxLength(255), Column("password")]
-    public required string Password { get; set; }
+    [Column("hashed_password")]
+    public required string HashedPassword { get; set; }
+    [Column("salt")]
+    public required string Salt { get; set; }
 
-    [MaxLength(100), Column("email")]
+    [Column("email")]
     public required string Email { get; set; }
 
     public List<SearchHistory> SearchHistories { get; } = [];


### PR DESCRIPTION
This PR implements hashing of password before storing in the db.

The implementation uses the `Rfc2898DeriveBytes` [class](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.rfc2898derivebytes?view=net-9.0) with a hash iteration count of 500.000.

Additionally the PR implements password requirements in according with the latest [NIST guidelines](https://blog.1password.com/nist-password-guidelines-update/).

Requires https://github.com/RUC-MSc-CS-CIT-2024/portfolio_subproject_1/pull/78 to be approved