### PR TITLE
feat: related data for following, bookmark & completed

### DIFF
--- a/src/CitMovie.Business/AutoMappers/AutoMapperProfile.cs
+++ b/src/CitMovie.Business/AutoMappers/AutoMapperProfile.cs
@@ -9,9 +9,6 @@ public class AutoMapperProfile : Profile
         CreateMap<UserUpdateRequest, User>();
         CreateMap<User, UserResult>();
 
-        // Follow
-        CreateMap<Follow, FollowResult>();
-
         // Country
         CreateMap<Country, CountryResult>();
 
@@ -114,10 +111,32 @@ public class AutoMapperProfile : Profile
         CreateMap<CastMember, CrewResult>()
             .ForMember(dest => dest.JobCategory, opt => opt.MapFrom(src => "Actor"));
 
-        // Bookmark & Completed
+        // Bookmark
         CreateMap<Bookmark, BookmarkResult>();
-        CreateMap<Completed, CompletedResult>();
+        CreateMap<Media, BookmarkResult.BookmarkMediaResult>()
+            .ForMember(dest => dest.Title, opt => opt.MapFrom(src => src.PrimaryInformation!.Title!.Name))
+            .ForMember(dest => dest.ReleaseDate, opt => {
+                opt.AllowNull();
+                opt.MapFrom(src => src.PrimaryInformation!.Release!.ReleaseDate);
+            })
+            .ForMember(dest => dest.PosterUri, opt => {
+                opt.AllowNull();
+                opt.MapFrom(src => src.PrimaryInformation!.PromotionalMedia!.Uri);
+            });
 
+        // Completed
+        CreateMap<Completed, CompletedResult>();
+        CreateMap<Media, CompletedResult.CompletedMediaResult>()
+            .ForMember(dest => dest.Title, opt => opt.MapFrom(src => src.PrimaryInformation!.Title!.Name))
+            .ForMember(dest => dest.PosterUri, opt => {
+                opt.AllowNull();
+                opt.MapFrom(src => src.PrimaryInformation!.PromotionalMedia!.Uri);
+            });
         CreateMap<CompletedCreateRequest, Completed>();
+
+        // Follow
+        CreateMap<Follow, FollowResult>();
+        CreateMap<Person, FollowResult.FollowPersonResult>()
+            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.PersonId));
     }
 }

--- a/src/CitMovie.Business/Managers/FollowManager.cs
+++ b/src/CitMovie.Business/Managers/FollowManager.cs
@@ -3,17 +3,28 @@ namespace CitMovie.Business;
 public class FollowManager : IFollowManager
 {
     private readonly IFollowRepository _followRepository;
+    private readonly IPersonRepository _personRepository;
+
     private readonly IMapper _mapper;
 
-    public FollowManager(IFollowRepository followRepository, IMapper mapper)
+    public FollowManager(IFollowRepository followRepository, IPersonRepository personRepository, IMapper mapper)
     {
         _followRepository = followRepository;
+        _personRepository = personRepository;
+
         _mapper = mapper;
     }
 
     public async Task<IEnumerable<FollowResult>> GetFollowingsAsync(int userId, int page, int pageSize)
     {
-        var followings = await _followRepository.GetFollowingsAsync(userId, page, pageSize);
+        IEnumerable<Follow> followings = await _followRepository.GetFollowingsAsync(userId, page, pageSize);
+        IEnumerable<FollowResult> results = _mapper.Map<IEnumerable<FollowResult>>(followings);
+        foreach (FollowResult result in results)
+        {   
+            Person? person = await _personRepository.GetPersonByIdAsync(result.PersonId);
+            if (person != null)
+                result.Person = _mapper.Map<FollowResult.FollowPersonResult>(person);
+        }
         return _mapper.Map<IEnumerable<FollowResult>>(followings);
     }
 

--- a/src/CitMovie.Models/DataTransferObjects/BookmarkDto.cs
+++ b/src/CitMovie.Models/DataTransferObjects/BookmarkDto.cs
@@ -6,6 +6,18 @@ public class BookmarkResult : BaseResult
     public int UserId { get; set; }
     public int MediaId { get; set; }
     public string? Note { get; set; }
+    public BookmarkMediaResult? Media { get; set; }
+
+    public class BookmarkMediaResult {
+        public required int Id { get; set; }
+        public required string Type { get; set; }
+        public required string Title { get; set; }
+        public DateTime? ReleaseDate { get; set; }
+        public string? AgeRating { get; set; }
+        public int? RuntimeMinutes { get; set; }
+        public string? PosterUri { get; set; }
+        public string? ImdbId { get; set; }
+    }
 }
 
 public class BookmarkCreateRequest

--- a/src/CitMovie.Models/DataTransferObjects/CompletedDto.cs
+++ b/src/CitMovie.Models/DataTransferObjects/CompletedDto.cs
@@ -13,6 +13,15 @@ public class CompletedResult : BaseResult
     public DateTime? CompletedDate { get; set; }
     public int Rewatchability { get; set; }
     public string? Note { get; set; }
+    public CompletedMediaResult? Media { get; set; }
+
+    public class CompletedMediaResult {
+        public required int Id { get; set; }
+        public required string Type { get; set; }
+        public required string Title { get; set; }
+        public string? PosterUri { get; set; }
+        public string? ImdbId { get; set; }
+    } 
 }
 
 public class CompletedCreateRequest

--- a/src/CitMovie.Models/DataTransferObjects/FollowDto.cs
+++ b/src/CitMovie.Models/DataTransferObjects/FollowDto.cs
@@ -5,6 +5,13 @@ public class FollowResult : BaseResult
     public required int FollowingId { get; set; }
     public required int PersonId { get; set; }
     public required DateTime FollowedSince { get; set; }
+    public FollowPersonResult? Person { get; set; }
+
+    public class FollowPersonResult {
+        public required int Id { get; set; }
+        public required string Name { get; set; }
+        public string? ImdbId { get; set; }
+    }
 };
 
 public class FollowCreateRequest

--- a/src/CitMovie.Models/DataTransferObjects/MediaDto.cs
+++ b/src/CitMovie.Models/DataTransferObjects/MediaDto.cs
@@ -22,6 +22,7 @@ public class MediaResult : BaseResult {
     public int? BoxOffice { get; set; }
     public int? Budget { get; set; }
     public string? AwardText { get; set; }
+    public string? ImdbId { get; set; }
     public List<GenreResult> Genres { get; set; } = [];
     public List<ScoreResult> Scores { get; set; } = [];
     public List<MediaProductionCompanyResult> ProductionCompanies { get; set; } = [];

--- a/src/CitMovie.Models/DataTransferObjects/PersonDto.cs
+++ b/src/CitMovie.Models/DataTransferObjects/PersonDto.cs
@@ -9,6 +9,7 @@ public class PersonResult : BaseResult
     public decimal? NameRating { get; set; }
     public DateTime? BirthDate { get; set; }
     public DateTime? DeathDate { get; set; }
+    public string? ImdbId { get; set; }
 }
 
 public class CoActorResult : BaseResult


### PR DESCRIPTION
Add related media and person information in the result set for bookmark, completed and follow endpoints. This is done to reduce the number of calls to the api.

Also adds the imdb id to the media and person dto since it is used for fetching poster and profile pic from tmdb