### PR TITLE
fix: links and other bugs

### DIFF
--- a/src/CitMovie.Api/Controller/CompletedController.cs
+++ b/src/CitMovie.Api/Controller/CompletedController.cs
@@ -1,4 +1,4 @@
-namespace CitMovie.Api.Controllers;
+namespace CitMovie.Api;
 
 [ApiController]
 [Route("api/users/{userId}/completed")]
@@ -40,7 +40,7 @@ public class CompletedController : ControllerBase
         if (completed.UserId != userId)
             return Forbid();
 
-        completed.Links = AddCompletedLinks(completed);
+        completed.Links = Url.AddCompletedLinks(completed.CompletedId, completed.MediaId, userId);
 
         return Ok(completed);
     }
@@ -52,7 +52,7 @@ public class CompletedController : ControllerBase
         var totalItems = await _completedManager.GetTotalUserCompletedCountAsync(userId);
 
         foreach (var completed in completedItems)
-            completed.Links = AddCompletedLinks(completed);
+            completed.Links = Url.AddCompletedLinks(completed.CompletedId, completed.MediaId, userId);
 
         var result = _pagingHelper.CreatePaging(nameof(GetUserCompleted), page.Number, page.Count, totalItems, completedItems, new { userId });
 
@@ -82,22 +82,4 @@ public class CompletedController : ControllerBase
         var deleted = await _completedManager.DeleteCompletedAsync(id);
         return deleted ? NoContent() : NotFound();
     }
-
-    private List<Link> AddCompletedLinks(CompletedResult completed)
-        => [ new Link {
-                Href = _pagingHelper.GetResourceLink(nameof(GetCompleted), new { userId = completed.UserId, id = completed.CompletedId }) ?? string.Empty,
-                Rel = "self",
-                Method = "GET"
-            }, 
-            new Link {
-                Href = _pagingHelper.GetResourceLink(nameof(UserController.GetUser), new { userId = completed.UserId }) ?? string.Empty,
-                Rel = "user",
-                Method = "GET"
-            },
-            new Link {
-                Href = _pagingHelper.GetResourceLink(nameof(MediaController.Get), new { id = completed.MediaId }) ?? string.Empty,
-                Rel = "media",
-                Method = "GET"
-            }
-        ];
 }

--- a/src/CitMovie.Api/Controller/FollowController.cs
+++ b/src/CitMovie.Api/Controller/FollowController.cs
@@ -24,18 +24,18 @@ public class FollowController : ControllerBase
         var totalItems = await _followManager.GetTotalFollowingsCountAsync(userId);
 
         foreach (var following in followings)
-            following.Links = AddFollowingLinks(following);
+            following.Links = Url.AddFollowLinks(following.PersonId, userId, following.FollowingId);
 
         var result = _pagingHelper.CreatePaging(nameof(GetFollowings), page.Number, page.Count, totalItems, followings, new { userId });
         return Ok(result);
     }
 
 
-    [HttpPost]
+    [HttpPost(Name = nameof(CreateFollow))]
     public async Task<ActionResult<FollowResult>> CreateFollow(int userId, [FromBody] FollowCreateRequest followCreateRequest)
     {
         var follow = await _followManager.CreateFollowAsync(userId, followCreateRequest.PersonId);
-        follow.Links = AddFollowingLinks(follow);
+        follow.Links = Url.AddFollowLinks(follow.PersonId, userId, follow.FollowingId);
         return CreatedAtAction(nameof(GetFollowings), new { userId }, follow);
     }
 
@@ -48,11 +48,4 @@ public class FollowController : ControllerBase
 
         return NoContent();
     }
-    private List<Link> AddFollowingLinks(FollowResult followResult)
-        => [ new Link {
-                Href = _pagingHelper.GetResourceLink(nameof(PersonController.GetPersonById), new { id = followResult.PersonId }) ?? string.Empty,
-                Rel = "person",
-                Method = "GET"
-            }
-        ];
 }

--- a/src/CitMovie.Api/Controller/MediaController.cs
+++ b/src/CitMovie.Api/Controller/MediaController.cs
@@ -50,8 +50,8 @@ public class MediaController : ControllerBase
         return Ok(results);
     }
 
-    [HttpGet("{id}", Name = nameof(Get))]
-    public ActionResult<MediaResult> Get(int id) {
+    [HttpGet("{id}", Name = nameof(GetMedia))]
+    public ActionResult<MediaResult> GetMedia(int id) {
         try {
             MediaResult m = _mediaManager.Get(id);
             m.Links = Url.AddMediaLinks(id);

--- a/src/CitMovie.Api/Controller/MediaController.cs
+++ b/src/CitMovie.Api/Controller/MediaController.cs
@@ -28,6 +28,10 @@ public class MediaController : ControllerBase
         }
         else
         {
+            if (queryParameter.Keywords is not null && queryParameter.Keywords.Length > 0)
+                for (int i = 0; i < queryParameter.Keywords.Length; i++)
+                    queryParameter.Keywords[i] = queryParameter.Keywords[i].ToLower();
+
             mediaResult = _mediaManager.Search(queryParameter, pageQuery, GetUserId());
             totalItems = _mediaManager.GetSearchResultsCount(queryParameter);
         }

--- a/src/CitMovie.Api/Controller/MediaController.cs
+++ b/src/CitMovie.Api/Controller/MediaController.cs
@@ -17,7 +17,7 @@ public class MediaController : ControllerBase
     }
 
     [HttpGet(Name = nameof(Query))]
-    public IActionResult Query([FromQuery] MediaQueryParameter queryParameter, [FromQuery(Name = "")] PageQueryParameter pageQuery)
+    public ActionResult<PagingResult<MediaBasicResult>> Query([FromQuery] MediaQueryParameter queryParameter, [FromQuery(Name = "")] PageQueryParameter pageQuery)
     {
         IEnumerable<MediaBasicResult> mediaResult;
         int totalItems = 0;
@@ -38,9 +38,9 @@ public class MediaController : ControllerBase
 
 
         foreach (var media in mediaResult)
-            media.Links = GenerateLinks(media.Id);
+            media.Links = Url.AddMediaLinks(media.Id);
 
-        var results = _pagingHelper.CreatePaging(
+        PagingResult<MediaBasicResult> results = _pagingHelper.CreatePaging(
             nameof(Query),
             pageQuery.Number,
             pageQuery.Count,
@@ -51,10 +51,10 @@ public class MediaController : ControllerBase
     }
 
     [HttpGet("{id}", Name = nameof(Get))]
-    public IActionResult Get(int id) {
+    public ActionResult<MediaResult> Get(int id) {
         try {
             MediaResult m = _mediaManager.Get(id);
-            m.Links = GenerateLinks(id);
+            m.Links = Url.AddMediaLinks(id);
             return Ok(m);
         } catch (KeyNotFoundException) {
             return NotFound();
@@ -65,16 +65,16 @@ public class MediaController : ControllerBase
     }
 
     [HttpGet("{id}/similar_media", Name = nameof(GetSimilar))]
-    public async Task<IActionResult> GetSimilar(int id, [FromQuery(Name = "")] PageQueryParameter pageQuery)
+    public async Task<ActionResult<PagingResult<MediaBasicResult>>> GetSimilar(int id, [FromQuery(Name = "")] PageQueryParameter pageQuery)
     {
         try
         {
             IEnumerable<MediaBasicResult> similarMedia = _mediaManager.GetSimilar(id, pageQuery);
             foreach (var media in similarMedia)
-                media.Links = GenerateLinks(media.Id);
+                media.Links = Url.AddMediaLinks(media.Id);
 
             var totalItems = await _mediaManager.GetTotalSimilarMediaCountAsync(id);
-            var result = _pagingHelper.CreatePaging(nameof(GetSimilar), pageQuery.Number, pageQuery.Count, totalItems, similarMedia, new { id });
+            PagingResult<MediaBasicResult> result = _pagingHelper.CreatePaging(nameof(GetSimilar), pageQuery.Number, pageQuery.Count, totalItems, similarMedia, new { id });
 
             return Ok(result);
         }
@@ -90,16 +90,16 @@ public class MediaController : ControllerBase
     }
 
     [HttpGet("{id}/related_media", Name = nameof(GetRelated))]
-    public async Task<IActionResult> GetRelated(int id, [FromQuery(Name = "")] PageQueryParameter pageQuery)
+    public async Task<ActionResult<PagingResult<MediaBasicResult>>> GetRelated(int id, [FromQuery(Name = "")] PageQueryParameter pageQuery)
     {
         try
         {
             IEnumerable<MediaBasicResult> relatedMedia = _mediaManager.GetRelated(id, pageQuery);
             foreach (var media in relatedMedia)
-                media.Links = GenerateLinks(media.Id);
+                media.Links = Url.AddMediaLinks(media.Id);
 
             int totalItems = await _mediaManager.GetTotalRelatedMediaCountAsync(id);
-            var result = _pagingHelper.CreatePaging(nameof(GetRelated), pageQuery.Number, pageQuery.Count, totalItems, relatedMedia, new { id });
+            PagingResult<MediaBasicResult> result = _pagingHelper.CreatePaging(nameof(GetRelated), pageQuery.Number, pageQuery.Count, totalItems, relatedMedia, new { id });
 
             return Ok(result);
         }
@@ -115,15 +115,15 @@ public class MediaController : ControllerBase
     }
 
     [HttpGet("{id}/crew", Name = nameof(GetCrew))]
-    public async Task<ActionResult> GetCrew(int id, [FromQuery(Name = "")] PageQueryParameter pageQuery) {
+    public async Task<ActionResult<PagingResult<CrewResult>>> GetCrew(int id, [FromQuery(Name = "")] PageQueryParameter pageQuery) {
         
         try {
             IEnumerable<CrewResult> crewResult = await _mediaManager.GetCrewAsync(id, pageQuery);
-            foreach (var media in crewResult)
-                media.Links = GenerateLinks(media.Id);
+            foreach (var crew in crewResult)
+                crew.Links = Url.AddCrewAndCastLinks(id, crew.PersonId);
 
             int totalItems = await _mediaManager.GetTotalCrewCountAsync(id);
-            var result = _pagingHelper.CreatePaging(nameof(GetRelated), pageQuery.Number, pageQuery.Count, totalItems, crewResult, new { id });
+            PagingResult<CrewResult> result = _pagingHelper.CreatePaging(nameof(GetCrew), pageQuery.Number, pageQuery.Count, totalItems, crewResult, new { id });
             return Ok(result);
         } catch (KeyNotFoundException) {
             return NotFound();
@@ -134,14 +134,14 @@ public class MediaController : ControllerBase
     }
 
     [HttpGet("{id}/cast", Name = nameof(GetCast))]
-    public async Task<IActionResult> GetCast(int id, [FromQuery(Name = "")] PageQueryParameter pageQuery) {
+    public async Task<ActionResult<PagingResult<CrewResult>>> GetCast(int id, [FromQuery(Name = "")] PageQueryParameter pageQuery) {
         try {
             IEnumerable<CrewResult> castResult = await _mediaManager.GetCastAsync(id, pageQuery);
-            foreach (var media in castResult)
-                media.Links = GenerateLinks(media.Id);
+            foreach (var cast in castResult)
+                cast.Links = Url.AddCrewAndCastLinks(id, cast.PersonId);
 
             int totalItems = await _mediaManager.GetTotalCastCountAsync(id);
-            var result = _pagingHelper.CreatePaging(nameof(GetRelated), pageQuery.Number, pageQuery.Count, totalItems, castResult, new { id });
+            PagingResult<CrewResult> result = _pagingHelper.CreatePaging(nameof(GetCast), pageQuery.Number, pageQuery.Count, totalItems, castResult, new { id });
             return Ok(result);
         } catch (KeyNotFoundException) {
             return NotFound();
@@ -159,23 +159,4 @@ public class MediaController : ControllerBase
             userId = parseResult;
         return userId;
     }
-
-    private List<Link> GenerateLinks(int mediaId)
-        => [
-            new Link {
-                Href = Url.Link(nameof(Get), new { id = mediaId }) ?? string.Empty,
-                Rel = "self",
-                Method = "GET"
-            },
-            new Link {
-                Href = Url.Link(nameof(GetSimilar), new { id = mediaId }) ?? string.Empty,
-                Rel = "similar_media",
-                Method = "GET"
-            },
-            new Link {
-                Href = Url.Link(nameof(GetRelated), new { id = mediaId }) ?? string.Empty,
-                Rel = "related_media",
-                Method = "GET"
-            }
-        ];
 }

--- a/src/CitMovie.Api/Controller/PersonController.cs
+++ b/src/CitMovie.Api/Controller/PersonController.cs
@@ -31,7 +31,7 @@ public class PersonController : ControllerBase
         );
 
         foreach (var person in persons)
-            person.Links = AddPersonLinks(person.Id);
+            person.Links = Url.AddPersonLinks(person.Id);
 
         return Ok(result);
     }
@@ -43,7 +43,7 @@ public class PersonController : ControllerBase
         if (person == null)
             return NotFound();
 
-        person.Links = AddPersonLinks(person.Id);
+        person.Links = Url.AddPersonLinks(id);
 
         return Ok(person);
     }
@@ -65,7 +65,8 @@ public class PersonController : ControllerBase
         foreach (PersonCrewResult m in media) {
             if (m.Media is null)
                 continue;
-            m.Media.Links = AddMediaLinks(m.Media);
+            m.Links = Url.AddCrewAndCastLinks(m.Media.Id, id);
+            m.Media.Links = Url.AddMediaLinks(m.Media.Id);
         }
 
         return Ok(result);
@@ -78,7 +79,7 @@ public class PersonController : ControllerBase
         var totalCount = await _personManager.GetFrequentCoActorsCountAsync(id);
 
         foreach (var ca in coActor)
-            ca.Links = AddPersonLinks(ca.Id);
+            ca.Links = Url.AddPersonLinks(ca.Id);
 
         var result = _pagingHelper.CreatePaging(
             nameof(GetFrequentCoActors),
@@ -99,25 +100,4 @@ public class PersonController : ControllerBase
             userId = parseResult;
         return userId;
     }
-
-    private List<Link> AddPersonLinks(int personId)
-        => [ new Link {
-                Href = _pagingHelper.GetResourceLink(nameof(GetPersonById), new { id = personId }) ?? string.Empty,
-                Rel = "self",
-                Method = "GET"
-            },
-            new Link {
-                Href = _pagingHelper.GetResourceLink(nameof(GetFrequentCoActors), new { id = personId }) ?? string.Empty,
-                Rel = "frequent-coactors",
-                Method = "GET"
-            }
-        ];
-
-    private List<Link> AddMediaLinks(PersonCrewResult.MediaResult media)
-        => [ new Link {
-                Href = _pagingHelper.GetResourceLink(nameof(MediaController.Get), new { id = media.Id }) ?? string.Empty,
-                Rel = "self",
-                Method = "GET"
-            }
-        ];
 }

--- a/src/CitMovie.Api/Controller/PromotionalMediaController.cs
+++ b/src/CitMovie.Api/Controller/PromotionalMediaController.cs
@@ -23,7 +23,7 @@ public class PromotionalMediaController : ControllerBase
             var totalItems = await _manager.GetPromotionalMediaCountAsync(mediaId, "media");
 
             foreach (var promotionalMedia in items)
-                promotionalMedia.Links = AddPromotionalMediaLinks(promotionalMedia, mediaId, promotionalMedia.ReleaseId);
+                promotionalMedia.Links = Url.AddPromotionalMediaLinks(promotionalMedia.PromotionalMediaId, mediaId, promotionalMedia.ReleaseId);
 
             var result = _pagingHelper.CreatePaging(
                 nameof(GetPromotionalMediaofMedia),
@@ -50,7 +50,7 @@ public class PromotionalMediaController : ControllerBase
             var totalItems = await _manager.GetPromotionalMediaCountAsync(releaseId, "release");
 
             foreach (var promotionalMedia in items)
-                promotionalMedia.Links = AddPromotionalMediaLinks(promotionalMedia, mediaId, promotionalMedia.ReleaseId);
+                promotionalMedia.Links = Url.AddPromotionalMediaLinks(promotionalMedia.PromotionalMediaId, mediaId, promotionalMedia.ReleaseId);
 
             var result = _pagingHelper.CreatePaging(
                 nameof(GetPromotionalMediaOfRelease),
@@ -76,7 +76,7 @@ public class PromotionalMediaController : ControllerBase
         {
             var result = await _manager.GetPromotionalMediaByIdAsync(id, mediaId, releaseId);
 
-            result.Links = AddPromotionalMediaLinks(result, mediaId, releaseId);
+            result.Links = Url.AddPromotionalMediaLinks(id, mediaId, releaseId);
             return Ok(result);
         }
         catch (Exception e)
@@ -102,12 +102,12 @@ public class PromotionalMediaController : ControllerBase
     }
 
     [HttpPost]
-    public async Task<IActionResult> CreatePromotionalMedia([FromRoute] int mediaId, [FromRoute] int releaseId, [FromBody] PromotionalMediaCreateRequest model)
+    public async Task<IActionResult> CreatePromotionalMedia(int mediaId, int releaseId, [FromBody] PromotionalMediaCreateRequest model)
     {
         try
         {
             var response = await _manager.CreatePromotionalMediaAsync(mediaId, releaseId, model);
-            response.Links = AddPromotionalMediaLinks(response, mediaId, releaseId);
+            response.Links = Url.AddPromotionalMediaLinks(response.PromotionalMediaId, mediaId, releaseId);
             return CreatedAtAction(nameof(CreatePromotionalMedia), response);
         }
         catch (Exception e)
@@ -115,22 +115,4 @@ public class PromotionalMediaController : ControllerBase
             return BadRequest(e.Message);
         }
     }
-
-    private List<Link> AddPromotionalMediaLinks(PromotionalMediaResult promotionalMedia, int mediaId, int releaseId)
-        => [ new Link {
-                Href = _pagingHelper.GetResourceLink(nameof(MediaController.Get), new { id = mediaId }) ?? string.Empty,
-                Rel = "media",
-                Method = "GET"
-            },
-            new Link {
-                Href = _pagingHelper.GetResourceLink(nameof(ReleaseController.GetReleaseOfMediaById), new { mediaId, id = releaseId }) ?? string.Empty,
-                Rel = "release",
-                Method = "GET"
-            },
-            new Link {
-                Href = _pagingHelper.GetResourceLink(nameof(GetPromotionalMediaOfRelease), new { mediaId, releaseId, promotionalMediaId = promotionalMedia.PromotionalMediaId }) ?? string.Empty,
-                Rel = "self",
-                Method = "GET"
-            }
-        ];
 }

--- a/src/CitMovie.Api/Controller/ReleaseController.cs
+++ b/src/CitMovie.Api/Controller/ReleaseController.cs
@@ -25,7 +25,7 @@ public class ReleaseController : ControllerBase
             var totalItems = await _releaseManager.GetReleasesCountAsync(mediaId);
 
             foreach (var release in releases)
-                release.Links = AddReleaseLinks(release);
+                release.Links = Url.AddReleaseLinks(mediaId, release.ReleaseId);
 
             var result = _pageHelper.CreatePaging(nameof(GetReleasesOfMedia), page.Number, page.Count, totalItems, releases, new { mediaId });
 
@@ -47,7 +47,7 @@ public class ReleaseController : ControllerBase
             if (release == null)
                 return NotFound();
             
-            release.Links = AddReleaseLinks(release);
+            release.Links = Url.AddReleaseLinks(mediaId, id);
 
             return Ok(release);
         }
@@ -63,7 +63,7 @@ public class ReleaseController : ControllerBase
         try
         {
             var release = await _releaseManager.DeleteReleaseOfMediaAsync(mediaId, id);
-            return Ok(release);
+            return NoContent();
 
         }
         catch (Exception e)
@@ -78,8 +78,8 @@ public class ReleaseController : ControllerBase
         try
         {
             var result = await _releaseManager.CreateReleaseForMediaAsync(mediaId, request);
-            result.Links = AddReleaseLinks(result);
-            return Ok(result);
+            result.Links = Url.AddReleaseLinks(mediaId, result.ReleaseId);
+            return CreatedAtAction(nameof(GetReleaseOfMediaById), new { mediaId, id = result.ReleaseId }, result);
         }
         catch (Exception e)
         {
@@ -93,7 +93,7 @@ public class ReleaseController : ControllerBase
         try
         {
             var result = await _releaseManager.UpdateReleaseForMediaAsync(mediaId, id, request);
-            result.Links = AddReleaseLinks(result);
+            result.Links = Url.AddReleaseLinks(mediaId, id);
             return Ok(result);
         }
         catch (Exception e)
@@ -101,17 +101,4 @@ public class ReleaseController : ControllerBase
             return BadRequest(e.Message);
         }
     }
-
-    private List<Link> AddReleaseLinks(ReleaseResult release)
-        => [ new Link {
-                Href = _pageHelper.GetResourceLink(nameof(GetReleaseOfMediaById), new { mediaId = release.MediaId, id = release.ReleaseId }) ?? string.Empty,
-                Rel = "self",
-                Method = "GET"
-            },
-            new Link {
-                Href = _pageHelper.GetResourceLink(nameof(MediaController.Get), new { id = release.MediaId }) ?? string.Empty,
-                Rel = "media",
-                Method = "GET"
-            }
-        ];
 }

--- a/src/CitMovie.Api/Controller/SearchHistoryController.cs
+++ b/src/CitMovie.Api/Controller/SearchHistoryController.cs
@@ -24,7 +24,7 @@ public class SearchHistoryController : ControllerBase
         var total_items = await _searchHistoryManager.GetUsersTotalSearchHistoriesCountAsync(userId);
 
         foreach (var searchHistory in searchHistories)
-            searchHistory.Links = AddSearchHistoryUserLink(searchHistory);
+            searchHistory.Links = Url.AddSearchHistoryUserLink(searchHistory.SearchHistoryId, userId);
 
         var result = _pagingHelper.CreatePaging(nameof(GetUserSearchHistories), page.Number, page.Count, total_items, searchHistories, new { userId });
 
@@ -32,6 +32,7 @@ public class SearchHistoryController : ControllerBase
     }
 
     [HttpDelete(Name = nameof(DeleteUserSearchHistories))]
+    [HttpDelete("{searchHistoryId}", Name = nameof(DeleteUserSearchHistories))]
     public async Task<IActionResult> DeleteUserSearchHistories(int userId, int searchHistoryId)
     {
         var result = await _searchHistoryManager.DeleteUsersSearchHistoriesAsync(userId, searchHistoryId);
@@ -42,13 +43,6 @@ public class SearchHistoryController : ControllerBase
         return NotFound();
     }
 
-    private List<Link> AddSearchHistoryUserLink(SearchHistoryResult searchHistoryResult)
-        => [ new Link
-            {
-                Href = _pagingHelper.GetResourceLink(nameof(UserController.GetUser), new { userId = searchHistoryResult.UserId }) ?? string.Empty,
-                Rel = "user",
-                Method = "GET"
-            }
-        ];
+
     
 }

--- a/src/CitMovie.Api/Controller/TitleController.cs
+++ b/src/CitMovie.Api/Controller/TitleController.cs
@@ -6,17 +6,25 @@ namespace CitMovie.Api;
 public class TitleController : ControllerBase {
     private readonly ITitleManager _titleManager;
     private readonly ILogger<TitleController> _logger;
+    private readonly PagingHelper _pagingHelper;
 
-    public TitleController(ITitleManager titleManager, ILogger<TitleController> logger)
+    public TitleController(ITitleManager titleManager, ILogger<TitleController> logger, PagingHelper pagingHelper)
     {
         _titleManager = titleManager;
         _logger = logger;
+        _pagingHelper = pagingHelper;
     }
 
-    [HttpGet]
-    public IActionResult GetAll(int mediaId, [FromQuery(Name = "")] PageQueryParameter page) {
+    [HttpGet(Name = nameof(GetAllTitles))]
+    public ActionResult<PagingResult<TitleResult>> GetAllTitles(int mediaId, [FromQuery(Name = "")] PageQueryParameter page) {
         try {
-            return Ok(_titleManager.GetAllForMedia(mediaId, page));
+            IEnumerable<TitleResult> results = _titleManager.GetAllForMedia(mediaId, page);
+            foreach (var result in results) {
+                result.Links = Url.AddTitleLinks(result.Id, mediaId);
+            }
+            int total = _titleManager.GetTotalTitlesCount(mediaId);
+            PagingResult<TitleResult> pagingResult = _pagingHelper.CreatePaging(nameof(GetAllTitles), page.Number, page.Count, total, results);
+            return Ok();
         } catch (KeyNotFoundException) {
             return NotFound();
         } catch (Exception e) {
@@ -25,10 +33,12 @@ public class TitleController : ControllerBase {
         }
     }
 
-    [HttpGet("{titleId}")]
-    public IActionResult Get(int mediaId, int titleId) {
+    [HttpGet("{titleId}", Name = nameof(GetTitle))]
+    public ActionResult<TitleResult> GetTitle(int mediaId, int titleId) {
         try {
-            return Ok(_titleManager.Get(mediaId, titleId));
+            TitleResult result = _titleManager.Get(mediaId, titleId);
+            result.Links = Url.AddTitleLinks(titleId, mediaId);
+            return Ok(result);
         } catch (KeyNotFoundException) {
             return NotFound();
         } catch (Exception e) {
@@ -37,23 +47,24 @@ public class TitleController : ControllerBase {
         }
     }
 
-    [HttpPost]
-    public async Task<IActionResult> Create(int mediaId, [FromBody] TitleCreateRequest createRequest) {
+    [HttpPost(Name = nameof(CreateTitle))]
+    public async Task<IActionResult> CreateTitle(int mediaId, [FromBody] TitleCreateRequest createRequest) {
         try {
             TitleResult newTitle = await _titleManager.CreateAsync(mediaId, createRequest);
+            newTitle.Links = Url.AddTitleLinks(newTitle.Id, mediaId);
             var routeValues = new {
                 mediaId,
                 titleId = newTitle.Id
             };
-            return CreatedAtAction(nameof(Get), routeValues, newTitle);
+            return CreatedAtAction(nameof(GetTitle), routeValues, newTitle);
         } catch (Exception ex) {
             _logger.LogInformation(ex, "Unexpected error:");
             return StatusCode(StatusCodes.Status500InternalServerError);
         }
     }
 
-    [HttpDelete("{titleId}")]
-    public async Task<IActionResult> Delete(int mediaId, int titleId) {
+    [HttpDelete("{titleId}", Name = nameof(DeleteTitle))]
+    public async Task<IActionResult> DeleteTitle(int mediaId, int titleId) {
         try {
             bool deleted = await _titleManager.DeleteAsync(mediaId, titleId);
             return deleted 

--- a/src/CitMovie.Api/Controller/UserScoreController.cs
+++ b/src/CitMovie.Api/Controller/UserScoreController.cs
@@ -31,7 +31,7 @@ public class UserScoreController : ControllerBase
         var scores = await _userScoreManager.GetScoresByUserIdAsync(userId, page.Number, page.Count, mediaType, mediaId, mediaName);
 
         foreach (var score in scores)
-            score.Links = AddUserScoreLinks(score);
+            score.Links = Url.AddUserScoreLinks(userId, score.MediaId);
 
         var result = _pagingHelper.CreatePaging(nameof(GetUserScores), page.Number, page.Count, totalCount, scores, new { userId, mediaType, mediaId, mediaName });
 
@@ -49,18 +49,4 @@ public class UserScoreController : ControllerBase
         await _userScoreManager.CreateUserScoreAsync(userId, userScoreCreateRequest);
         return CreatedAtRoute(nameof(GetUserScores), new { userId }, null);
     }
-
-
-    private List<Link> AddUserScoreLinks(UserScoreResult userScore)
-        => [ new Link {
-                Href = _pagingHelper.GetResourceLink(nameof(UserController.GetUser), new { userId = userScore.UserId }) ?? string.Empty,
-                Rel = "user",
-                Method = "GET"
-            }, 
-            new Link {
-                Href = _pagingHelper.GetResourceLink(nameof(MediaController.Get), new { id = userScore.MediaId }) ?? string.Empty,
-                Rel = "media",
-                Method = "GET"
-            }
-        ];
 }

--- a/src/CitMovie.Api/Helpers/IUrlHelperExtensions.cs
+++ b/src/CitMovie.Api/Helpers/IUrlHelperExtensions.cs
@@ -1,0 +1,322 @@
+namespace CitMovie.Api;
+public static class IUrlHelperExtensions
+{
+    public static List<Link> AddMediaLinks(this IUrlHelper source, int mediaId)
+        => [
+            new Link {
+                Href = source.Link(nameof(MediaController.Get), new { id = mediaId }) ?? string.Empty,
+                Rel = "self",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(MediaController.GetSimilar), new { id = mediaId }) ?? string.Empty,
+                Rel = "similar_media",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(MediaController.GetRelated), new { id = mediaId }) ?? string.Empty,
+                Rel = "related_media",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(MediaController.GetCrew), new { id = mediaId }) ?? string.Empty,
+                Rel = "crew",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(MediaController.GetCast), new { id = mediaId }) ?? string.Empty,
+                Rel = "cast",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(PromotionalMediaController.GetPromotionalMediaofMedia), new { mediaId }) ?? string.Empty,
+                Rel = "promotional_media",
+                Method = "GET"
+            }
+        ];
+
+    public static List<Link> AddCrewAndCastLinks(this IUrlHelper source, int mediaId, int personId)
+        => [
+            new Link {
+                Href = source.Link(nameof(MediaController.Get), new { id = mediaId }) ?? string.Empty,
+                Rel = "media",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(PersonController.GetPersonById), new { id = personId }) ?? string.Empty,
+                Rel = "person",
+                Method = "GET"
+            },
+        ];
+    
+    public static List<Link> AddFollowLinks(this IUrlHelper source, int personId, int userId, int followId)
+        => [ 
+            new Link {
+                Href = source.Link(nameof(FollowController.CreateFollow), new { userId }) ?? string.Empty,
+                Rel = "create_follow",
+                Method = "POST"
+            },
+            new Link {
+                Href = source.Link(nameof(FollowController.RemoveFollowing), new { userId, followingId = followId }) ?? string.Empty,
+                Rel = "remove_follow",
+                Method = "DELETE"
+            },
+            new Link {
+                Href = source.Link(nameof(PersonController.GetPersonById), new { id = personId }) ?? string.Empty,
+                Rel = "person",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(UserController.GetUser), new { userId }) ?? string.Empty,
+                Rel = "user",
+                Method = "GET"
+            },
+        ];
+
+    public static List<Link> AddCompletedLinks(this IUrlHelper source, int completedId, int mediaId, int userId)
+        => [
+            new Link {
+                Href = source.Link(nameof(CompletedController.GetCompleted), new { userId, id = completedId }) ?? string.Empty,
+                Rel = "self",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(CompletedController.MoveBookmarkToCompleted), new { userId }) ?? string.Empty,
+                Rel = "move_to_completed",
+                Method = "POST"
+            },
+            new Link {
+                Href = source.Link(nameof(CompletedController.UpdateCompleted), new { userId, id = completedId }) ?? string.Empty,
+                Rel = "update_completed",
+                Method = "PUT"
+            },
+            new Link {
+                Href = source.Link(nameof(CompletedController.DeleteCompleted), new { userId, id = completedId }) ?? string.Empty,
+                Rel = "remove_completed",
+                Method = "DELETE"
+            },
+            new Link {
+                Href = source.Link(nameof(UserController.GetUser), new { userId }) ?? string.Empty,
+                Rel = "user",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(MediaController.Get), new { id = mediaId }) ?? string.Empty,
+                Rel = "media",
+                Method = "GET"
+            }
+        ];
+    
+    public static List<Link> AddBookmarkLinks(this IUrlHelper source, int bookmarkId, int mediaId, int userId)
+        => [
+            new Link {
+                Href = source.Link(nameof(BookmarkController.GetBookmark), new { userId, id = bookmarkId }) ?? string.Empty,
+                Rel = "self",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(BookmarkController.CreateBookmark), new { userId }) ?? string.Empty,
+                Rel = "create_bookmark",
+                Method = "POST"
+            },
+            new Link {
+                Href = source.Link(nameof(BookmarkController.MoveBookmarkToCompleted), new { userId, id = bookmarkId }) ?? string.Empty,
+                Rel = "move_to_completed",
+                Method = "POST"
+            },
+            new Link {
+                Href = source.Link(nameof(BookmarkController.UpdateBookmark), new { userId, id = bookmarkId }) ?? string.Empty,
+                Rel = "update_bookmark",
+                Method = "PATCH"
+            },
+            new Link {
+                Href = source.Link(nameof(BookmarkController.DeleteBookmark), new { userId, id = bookmarkId }) ?? string.Empty,
+                Rel = "delete_bookmark",
+                Method = "DELETE"
+            },
+            new Link {
+                Href = source.Link(nameof(UserController.GetUser), new { userId }) ?? string.Empty,
+                Rel = "user",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(MediaController.Get), new { id = mediaId }) ?? string.Empty,
+                Rel = "media",
+                Method = "GET"
+            }
+        ];
+
+    public static List<Link> AddPersonLinks(this IUrlHelper source, int personId)
+        => [ 
+            new Link {
+                Href = source.Link(nameof(PersonController.GetPersonById), new { id = personId }) ?? string.Empty,
+                Rel = "self",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(PersonController.GetFrequentCoActors), new { id = personId }) ?? string.Empty,
+                Rel = "coactors",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(PersonController.GetMediaByPersonId), new { id = personId }) ?? string.Empty,
+                Rel = "media",
+                Method = "GET"
+            }
+        ];
+
+    public static List<Link> AddPromotionalMediaLinks(this IUrlHelper source, int promotionalMediaId, int mediaId, int releaseId)
+        => [ 
+            new Link {
+                Href = source.Link(nameof(PromotionalMediaController.GetPromotionalMediaById), new { id = promotionalMediaId, mediaId, releaseId }) ?? string.Empty,
+                Rel = "self",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(PromotionalMediaController.CreatePromotionalMedia), new { mediaId, releaseId }) ?? string.Empty,
+                Rel = "create_promotional_media",
+                Method = "POST"
+            },
+            new Link {
+                Href = source.Link(nameof(PromotionalMediaController.DeletePromotionalMedia), new { mediaId, releaseId, id = promotionalMediaId }) ?? string.Empty,
+                Rel = "delete_promotional_media",
+                Method = "DELETE"
+            },
+            new Link {
+                Href = source.Link(nameof(ReleaseController.GetReleaseOfMediaById), new { mediaId, id = releaseId }) ?? string.Empty,
+                Rel = "release",
+                Method = "GET"
+            },
+        ];
+    
+    public static List<Link> AddReleaseLinks(this IUrlHelper source, int mediaId, int releaseId)
+        => [ 
+            new Link {
+                Href = source.Link(nameof(ReleaseController.GetReleaseOfMediaById), new { mediaId, id = releaseId }) ?? string.Empty,
+                Rel = "self",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(ReleaseController.CreateReleaseForMediaAsync), new { mediaId }) ?? string.Empty,
+                Rel = "create_release",
+                Method = "POST"
+            },
+            new Link {
+                Href = source.Link(nameof(ReleaseController.DeleteReleaseOfMediaAsync), new { mediaId, id = releaseId }) ?? string.Empty,
+                Rel = "delete_release",
+                Method = "DELETE"
+            },
+            new Link {
+                Href = source.Link(nameof(MediaController.Get), new { id = mediaId }) ?? string.Empty,
+                Rel = "media",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(PromotionalMediaController.GetPromotionalMediaOfRelease), new { mediaId, releaseId }) ?? string.Empty,
+                Rel = "promotional_media",
+                Method = "GET"
+            }
+        ];
+
+    public static List<Link> AddSearchHistoryUserLink(this IUrlHelper source, int searchHistoryId, int userId)
+        => [
+            new Link {
+                Href = source.Link(nameof(SearchHistoryController.DeleteUserSearchHistories), new { userId, searchHistoryId }) ?? string.Empty,
+                Rel = "delete_search_history",
+                Method = "DELETE"
+            },
+            new Link
+            {
+                Href = source.Link(nameof(UserController.GetUser), new { userId }) ?? string.Empty,
+                Rel = "user",
+                Method = "GET"
+            }
+        ];
+    
+    public static List<Link> AddTitleLinks(this IUrlHelper source, int titleId, int mediaId)
+        => [
+            new Link {
+                Href = source.Link(nameof(TitleController.GetTitle), new { mediaId, titleId }) ?? string.Empty,
+                Rel = "self",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(TitleController.CreateTitle), new { mediaId }) ?? string.Empty,
+                Rel = "create_title",
+                Method = "POST"
+            },
+            new Link {
+                Href = source.Link(nameof(TitleController.DeleteTitle), new { mediaId, titleId }) ?? string.Empty,
+                Rel = "delete_title",
+                Method = "DELETE"
+            },
+            new Link {
+                Href = source.Link(nameof(MediaController.Get), new { mediaId }) ?? string.Empty,
+                Rel = "media",
+                Method = "GET"
+            }
+        ];
+    
+    public static List<Link> AddUserLinks(this IUrlHelper source, int userId)
+        => [
+            new Link {
+                Href = source.Link(nameof(UserController.GetUser), new { userId }) ?? string.Empty,
+                Rel = "self",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(UserController.UpdateUser), new { userId }) ?? string.Empty,
+                Rel = "update_user",
+                Method = "PATCH"
+            },
+            new Link {
+                Href = source.Link(nameof(UserController.DeleteUser), new { userId }) ?? string.Empty,
+                Rel = "delete_user",
+                Method = "DELETE"
+            },
+            new Link {
+                Href = source.Link(nameof(UserScoreController.GetUserScores), new { userId }) ?? string.Empty,
+                Rel = "user_scores",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(CompletedController.GetUserCompleted), new { userId }) ?? string.Empty,
+                Rel = "completed",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(BookmarkController.GetUserBookmarks), new { userId }) ?? string.Empty,
+                Rel = "bookmarks",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(FollowController.GetFollowings), new { userId }) ?? string.Empty,
+                Rel = "followers",
+                Method = "GET"
+            },
+        ];
+    
+    public static List<Link> AddUserScoreLinks(this IUrlHelper source, int userId, int mediaId)
+        => [
+            new Link {
+                Href = source.Link(nameof(UserScoreController.GetUserScores), new { userId }) ?? string.Empty,
+                Rel = "self",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(UserScoreController.CreateUserScore), new { userId }) ?? string.Empty,
+                Rel = "create_user_score",
+                Method = "POST"
+            },
+            new Link {
+                Href = source.Link(nameof(UserScoreController.GetUserScores), new { userId }) ?? string.Empty,
+                Rel = "user",
+                Method = "GET"
+            },
+            new Link {
+                Href = source.Link(nameof(MediaController.Get), new { id = mediaId }) ?? string.Empty,
+                Rel = "media",
+                Method = "GET"
+            }
+        ];
+}

--- a/src/CitMovie.Api/Helpers/IUrlHelperExtensions.cs
+++ b/src/CitMovie.Api/Helpers/IUrlHelperExtensions.cs
@@ -4,7 +4,7 @@ public static class IUrlHelperExtensions
     public static List<Link> AddMediaLinks(this IUrlHelper source, int mediaId)
         => [
             new Link {
-                Href = source.Link(nameof(MediaController.Get), new { id = mediaId }) ?? string.Empty,
+                Href = source.Link(nameof(MediaController.GetMedia), new { id = mediaId }) ?? string.Empty,
                 Rel = "self",
                 Method = "GET"
             },
@@ -38,7 +38,7 @@ public static class IUrlHelperExtensions
     public static List<Link> AddCrewAndCastLinks(this IUrlHelper source, int mediaId, int personId)
         => [
             new Link {
-                Href = source.Link(nameof(MediaController.Get), new { id = mediaId }) ?? string.Empty,
+                Href = source.Link(nameof(MediaController.GetMedia), new { id = mediaId }) ?? string.Empty,
                 Rel = "media",
                 Method = "GET"
             },
@@ -101,7 +101,7 @@ public static class IUrlHelperExtensions
                 Method = "GET"
             },
             new Link {
-                Href = source.Link(nameof(MediaController.Get), new { id = mediaId }) ?? string.Empty,
+                Href = source.Link(nameof(MediaController.GetMedia), new { id = mediaId }) ?? string.Empty,
                 Rel = "media",
                 Method = "GET"
             }
@@ -140,7 +140,7 @@ public static class IUrlHelperExtensions
                 Method = "GET"
             },
             new Link {
-                Href = source.Link(nameof(MediaController.Get), new { id = mediaId }) ?? string.Empty,
+                Href = source.Link(nameof(MediaController.GetMedia), new { id = mediaId }) ?? string.Empty,
                 Rel = "media",
                 Method = "GET"
             }
@@ -207,7 +207,7 @@ public static class IUrlHelperExtensions
                 Method = "DELETE"
             },
             new Link {
-                Href = source.Link(nameof(MediaController.Get), new { id = mediaId }) ?? string.Empty,
+                Href = source.Link(nameof(MediaController.GetMedia), new { id = mediaId }) ?? string.Empty,
                 Rel = "media",
                 Method = "GET"
             },
@@ -251,7 +251,7 @@ public static class IUrlHelperExtensions
                 Method = "DELETE"
             },
             new Link {
-                Href = source.Link(nameof(MediaController.Get), new { mediaId }) ?? string.Empty,
+                Href = source.Link(nameof(MediaController.GetMedia), new { mediaId }) ?? string.Empty,
                 Rel = "media",
                 Method = "GET"
             }
@@ -314,7 +314,7 @@ public static class IUrlHelperExtensions
                 Method = "GET"
             },
             new Link {
-                Href = source.Link(nameof(MediaController.Get), new { id = mediaId }) ?? string.Empty,
+                Href = source.Link(nameof(MediaController.GetMedia), new { id = mediaId }) ?? string.Empty,
                 Rel = "media",
                 Method = "GET"
             }

--- a/src/CitMovie.Business/AutoMappers/AutoMapperProfile.cs
+++ b/src/CitMovie.Business/AutoMappers/AutoMapperProfile.cs
@@ -116,6 +116,7 @@ public class AutoMapperProfile : Profile
             .ForMember(dest => dest.JobCategory, opt => opt.MapFrom(src => src.JobCategory!.Name));
         CreateMap<CastMember, PersonCrewResult>()
             .ForMember(dest => dest.JobCategory, opt => opt.MapFrom(src => "actor"));
+
         CreateMap<Media, PersonCrewResult.MediaResult>()
             .ForMember(dest => dest.Title, opt => opt.MapFrom(src => src.PrimaryInformation!.Title!.Name))
             .ForMember(dest => dest.ReleaseDate, opt => {
@@ -126,6 +127,16 @@ public class AutoMapperProfile : Profile
                 opt.AllowNull();
                 opt.MapFrom(src => src.PrimaryInformation!.PromotionalMedia!.Uri);
             });
+        
+        CreateMap<Episode, PersonCrewResult.MediaResult>()
+            .IncludeBase<Media, PersonCrewResult.MediaResult>()
+            .ForMember(dest => dest.SeriesId, opt => {
+                opt.AllowNull();
+                opt.MapFrom(src => src.Season!.SeriesId);
+            });
+        
+        CreateMap<Season, PersonCrewResult.MediaResult>()
+            .IncludeBase<Media, PersonCrewResult.MediaResult>();
 
         // Bookmark
         CreateMap<Bookmark, BookmarkResult>();

--- a/src/CitMovie.Business/ManagerInterfaces/ITitleManager.cs
+++ b/src/CitMovie.Business/ManagerInterfaces/ITitleManager.cs
@@ -5,4 +5,5 @@ public interface ITitleManager {
     TitleResult Get(int mediaId, int titleId);
     Task<TitleResult> CreateAsync(int mediaId, TitleCreateRequest createRequest);
     Task<bool> DeleteAsync(int mediaId, int titleId);
+    int GetTotalTitlesCount(int mediaId);
 }

--- a/src/CitMovie.Business/Managers/MediaManager.cs
+++ b/src/CitMovie.Business/Managers/MediaManager.cs
@@ -76,13 +76,18 @@ public class MediaManager : IMediaManager {
             _ => []
         };
 
-        IEnumerable<MediaBasicResult> basicMedia = _mapper.Map<IEnumerable<MediaBasicResult>>(result.OfType<Media>());
-        IEnumerable<MediaBasicResult> episodes = _mapper.Map<IEnumerable<MediaBasicResult>>(result.OfType<Episode>());
+        List<MediaBasicResult> mediaResult = [];
+        foreach(Media media in result)
+        {
+            if (media is Episode e)
+                mediaResult.Add(_mapper.Map<MediaBasicResult>(e));
+            else if (media is Season s)
+                mediaResult.Add(_mapper.Map<MediaBasicResult>(s));
+            else
+                mediaResult.Add(_mapper.Map<MediaBasicResult>(media));
+        }
         
-        return basicMedia.Concat(episodes)
-            .DistinctBy(x => x.Id)
-            .OrderBy(x => x.Id)
-            .ThenBy(x => x.Title); 
+        return mediaResult; 
     }
 
     public async Task<int> GetTotalRelatedMediaCountAsync(int id)

--- a/src/CitMovie.Business/Managers/PersonManager.cs
+++ b/src/CitMovie.Business/Managers/PersonManager.cs
@@ -45,12 +45,17 @@ public class PersonManager : IPersonManager
 
     public async Task<IEnumerable<PersonCrewResult>> GetMediaByPersonIdAsync(int id, int page, int pageSize)
     {
-        IEnumerable<CrewBase> media = await _personRepository.GetMediaByPersonIdAsync(id, page, pageSize);
+        IEnumerable<CrewBase> crewBaseList = await _personRepository.GetMediaByPersonIdAsync(id, page, pageSize);
 
-        IEnumerable<PersonCrewResult> crewResults = _mapper.Map<IEnumerable<PersonCrewResult>>(media.OfType<CrewMember>());
-        IEnumerable<PersonCrewResult> castResults = _mapper.Map<IEnumerable<PersonCrewResult>>(media.OfType<CastMember>());
-
-        return crewResults.Concat(castResults);
+        List<PersonCrewResult> result = [];
+        foreach (CrewBase c in crewBaseList) {
+            if (c is CrewMember crew) {
+                result.Add(_mapper.Map<PersonCrewResult>(crew));
+            } else if (c is CastMember cast) {
+                result.Add(_mapper.Map<PersonCrewResult>(cast));
+            }
+        }
+        return result;
     }
 
     public async Task<int> GetMediaByPersonIdCountAsync(int id)
@@ -76,7 +81,5 @@ public class PersonManager : IPersonManager
     }
 
     public async Task<int> GetFrequentCoActorsCountAsync(int id)
-    {
-        return await _personRepository.GetFrequentCoActorsCountAsync(id);
-    }
+        => await _personRepository.GetFrequentCoActorsCountAsync(id);
 }

--- a/src/CitMovie.Business/Managers/TitleManager.cs
+++ b/src/CitMovie.Business/Managers/TitleManager.cs
@@ -62,4 +62,8 @@ public class TitleManager : ITitleManager
         IEnumerable<Title> result = _titleRepository.GetForMedia(mediaId);
         return _mapper.Map<IEnumerable<TitleResult>>(result);
     }
+
+    public int GetTotalTitlesCount(int mediaId)
+        => _titleRepository.GetTotalTitles(mediaId);
+
 }

--- a/src/CitMovie.Data/Repositories/PersonRepository.cs
+++ b/src/CitMovie.Data/Repositories/PersonRepository.cs
@@ -95,6 +95,8 @@ public class PersonRepository : IPersonRepository
                 .Include(cm => cm.Media!)
                 .ThenInclude(m => m.PrimaryInformation!)
                 .ThenInclude(pi => pi.PromotionalMedia)
+                .Include(cm => cm.Media!)
+                .ThenInclude(x => (x as Episode)!.Season)
                 .ToListAsync();
             result.AddRange(crewResult);
         }
@@ -117,12 +119,11 @@ public class PersonRepository : IPersonRepository
                 .ThenInclude(m => m.PrimaryInformation!)
                 .ThenInclude(pi => pi.PromotionalMedia)
                 .Include(cm => cm.Media!)
-                .ThenInclude(m => m.Scores)
+                .ThenInclude(x => (x as Episode)!.Season)
                 .ToListAsync();
             result.AddRange(castResult);
         }
         
-        Console.WriteLine(result.Count);
         return result
             .OrderByDescending(x => x.Media!.PrimaryInformation!.Release!.ReleaseDate)
             .ToList();

--- a/src/CitMovie.Data/Repositories/TitleRepository.cs
+++ b/src/CitMovie.Data/Repositories/TitleRepository.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-
 namespace CitMovie.Data;
 
 public class TitleRepository : ITitleRepository {
@@ -46,4 +44,9 @@ public class TitleRepository : ITitleRepository {
             .Include(x => x.TitleAttributes)
             .Include(x => x.TitleTypes)
             .Where(x => x.MediaId == mediaId);
+
+    public int GetTotalTitles(int mediaId)
+        => _context.Titles
+            .Count(x => x.MediaId == mediaId);
+
 }

--- a/src/CitMovie.Data/RepositoryInterfaces/ITitleRepository.cs
+++ b/src/CitMovie.Data/RepositoryInterfaces/ITitleRepository.cs
@@ -5,4 +5,5 @@ public interface ITitleRepository {
     Title Get(int titleId);
     Task<Title> CreateAsync(Title title);
     Task<bool> DeleteAsync(int  titleId);
+    int GetTotalTitles(int mediaId);
 }

--- a/src/CitMovie.Models/DataTransferObjects/PersonDto.cs
+++ b/src/CitMovie.Models/DataTransferObjects/PersonDto.cs
@@ -33,6 +33,10 @@ public class PersonCrewResult : BaseResult {
         public required string Title { get; set; }
         public DateTime? ReleaseDate { get; set; }
         public string? PosterUri { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? SeasonId { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? SeriesId { get; set; }
     }
 }
 

--- a/src/CitMovie.Models/DataTransferObjects/TitleDto.cs
+++ b/src/CitMovie.Models/DataTransferObjects/TitleDto.cs
@@ -1,6 +1,6 @@
 namespace CitMovie.Models.DataTransferObjects;
 
-public record TitleResult {
+public class TitleResult : BaseResult {
     public int Id { get; set; }
     public required string Name { get; set; }
     public IEnumerable<TitleTypeResult> Types { get; set; } = [];

--- a/src/CitMovie.Models/DomainObjects/Episode.cs
+++ b/src/CitMovie.Models/DomainObjects/Episode.cs
@@ -9,5 +9,5 @@ public class Episode : Media
     [Column("season_id")]
     public required int SeasonId { get; set; }
     
-    public Media? Season { get; set; }
+    public Season? Season { get; set; }
 }


### PR DESCRIPTION
- fix: person media now contains `seasonId` and `seriesId` if `episode` or `season` 
- fix: keywords in query automatically made lowercase
- fix: order of media query was lost during model to dto conversion
- fix: wrong page links for media `cast` and `crew` endpoints 
- refactor: same links for same resources with new extension methods